### PR TITLE
Add git executable

### DIFF
--- a/py2/Dockerfile
+++ b/py2/Dockerfile
@@ -1,2 +1,3 @@
 FROM cdrx/pyinstaller-windows:python2
+RUN apt update && apt install -y git-core
 ENTRYPOINT []

--- a/py3/Dockerfile
+++ b/py3/Dockerfile
@@ -1,2 +1,3 @@
 FROM cdrx/pyinstaller-windows:python3
+RUN apt update && apt install -y git-core
 ENTRYPOINT []


### PR DESCRIPTION
For my CI pipeline, I have to check out a repository. The CI system can't do it for me. Therefore I'm in need of a builder that has git included.

If this is covered by the idea behind this repository, would you consider merging it? I would also understand if it's outside of this repo's scope, and it will not be merged here.